### PR TITLE
Fix issue injection vulnerability

### DIFF
--- a/.github/workflows/run-onboarding-service.yaml
+++ b/.github/workflows/run-onboarding-service.yaml
@@ -12,11 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: View issue information
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           echo "🎉 The job automatically triggered by a ${{ github.event_name }} event."
-          echo "Issue title: ${{ github.event.issue.title }}"
+          echo "Issue title: $ISSUE_TITLE"
           echo "Issue No: ${{ github.event.issue.number }}"
-          echo "Issue body: ${{ github.event.issue.body }}"
+          echo "Issue body: $ISSUE_BODY"
       - name: Creating new Temp sub dir 'service'
         run:  |
          mkdir -m 777 service


### PR DESCRIPTION
I mentioned that this repo is vulnerable in https://github.com/Fiserv/Support/issues/423 but didn't get any info on how to report it privately.

This PR will fix the vulnerability. Essentially this repository is vulnerable to issue title/body injection, so anyone can create a new tenant onboarding request and run arbitrary code in the context of the main branch. They can use this to steal secrets (in particular, `secrets.ZIP_GENERATOR_ACTION`, which is most likely a GitHub PAT that will allow lateral movement to other repositories). See https://securitylab.github.com/research/github-actions-untrusted-input/ for info on how this vulnerability works.