### PR TITLE
Port 8749 test

### DIFF
--- a/.github/workflows/run-onboarding-service.yaml
+++ b/.github/workflows/run-onboarding-service.yaml
@@ -68,7 +68,7 @@ jobs:
           echo "TENANT="$result >> $GITHUB_OUTPUT          
           echo "Onboarding config writer Ran Successfully....🍏"
           cd ${{ github.workspace }}/service
-          tenant=$(./startup.sh -f '-rthbde')
+          tenant=$(./startup.sh -f '-rthde')
           echo "tenant"
           fi  
       - run: |
@@ -102,3 +102,10 @@ jobs:
           user_email: 'abhishek.singh3@fiserv.com'
           user_name: 'asingh2023'
           commit_message: 'pushing DbScript file remotely'          
+      - name: Applying Branch Protection.....
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
+        run: |
+          cd ${{ github.workspace }}/service
+          tenant=$(./tenant-onboarding -eb)
+          echo "tenant"

--- a/.github/workflows/run-onboarding-service.yaml
+++ b/.github/workflows/run-onboarding-service.yaml
@@ -107,5 +107,5 @@ jobs:
           GITHUB_AUTH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
         run: |
           cd ${{ github.workspace }}/service
-          tenant=$(./tenant-onboarding -eb)
+          tenant=$(./target/debug/tenant-onboarding -eb)
           echo "tenant"


### PR DESCRIPTION
Add branch protection at end of the workflow to allow the `tenant.json` to be copied to the `config` directory of the newly created repo.