### PR TITLE
PORT-8749 Use startup script to invoke tenant-onboarding executable

### DIFF
--- a/.github/workflows/run-onboarding-service.yaml
+++ b/.github/workflows/run-onboarding-service.yaml
@@ -107,5 +107,5 @@ jobs:
           GITHUB_AUTH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
         run: |
           cd ${{ github.workspace }}/service
-          tenant=$(./target/debug/tenant-onboarding -eb)
+          tenant=$(./startup.sh -f '-be')
           echo "tenant"


### PR DESCRIPTION
PR to test adding branch protection at the end of the workflow to allow the tenant.json to be copied to the newly created repo