### PR TITLE
PORT-8749 Changes for latest tenant-onboarding program

### DIFF
--- a/.github/workflows/run-onboarding-service.yaml
+++ b/.github/workflows/run-onboarding-service.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Tenant-Onboarding-Process:
-    if: github.event.label.name == 'PORT-8749-test'
+    if: github.event.label.name == 'Onboard New Tenant'
     runs-on: ubuntu-latest
     steps:
       - name: View issue information
@@ -68,7 +68,7 @@ jobs:
           echo "TENANT="$result >> $GITHUB_OUTPUT          
           echo "Onboarding config writer Ran Successfully....🍏"
           cd ${{ github.workspace }}/service
-          tenant=$(./startup.sh -f '-rthbde')
+          tenant=$(./startup.sh -f '-rthde')
           echo "tenant"
           fi  
       - run: |
@@ -102,3 +102,10 @@ jobs:
           user_email: 'abhishek.singh3@fiserv.com'
           user_name: 'asingh2023'
           commit_message: 'pushing DbScript file remotely'          
+      - name: Applying Branch Protection.....
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
+        run: |
+          cd ${{ github.workspace }}/service
+          tenant=$(./startup.sh -f '-be')
+          echo "tenant"


### PR DESCRIPTION
This PR sets the `GITHUB_AUTH_TOKEN` env variable when running the `tenant-onboarding` program and it invokes the `tenant-onboarding` program at the end of the workflow to add branch protections to the newly created repo. 

The branch protection is added at the end of the workflow to allow the `tenant.json` file to be copied to the repo (which would not be allowed if the branch protection was in place).